### PR TITLE
Update to latest Twig

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "psr/http-message": "^1.0",
         "react/http": "^0.8.0",
         "ringcentral/psr7": "^1.2.2",
-        "twig/twig": "^2.8"
+        "twig/twig": "^3.0"
     },
     "require-dev": {
         "wyrihaximus/async-test-utilities": "^1.1"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ffd61647100907626d3534b6b4140ca1",
+    "content-hash": "6199e909e30d75bff51c0d003f3e95e5",
     "packages": [
         {
             "name": "evenement/evenement",
@@ -698,38 +698,34 @@
         },
         {
             "name": "twig/twig",
-            "version": "v2.12.2",
+            "version": "v3.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/twigphp/Twig.git",
-                "reference": "d761fd1f1c6b867ae09a7d8119a6d95d06dc44ed"
+                "reference": "3b88ccd180a6b61ebb517aea3b1a8906762a1dc2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig/zipball/d761fd1f1c6b867ae09a7d8119a6d95d06dc44ed",
-                "reference": "d761fd1f1c6b867ae09a7d8119a6d95d06dc44ed",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/3b88ccd180a6b61ebb517aea3b1a8906762a1dc2",
+                "reference": "3b88ccd180a6b61ebb517aea3b1a8906762a1dc2",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0",
+                "php": "^7.2.5",
                 "symfony/polyfill-ctype": "^1.8",
                 "symfony/polyfill-mbstring": "^1.3"
             },
             "require-dev": {
                 "psr/container": "^1.0",
-                "symfony/debug": "^3.4|^4.2",
-                "symfony/phpunit-bridge": "^4.4@dev|^5.0"
+                "symfony/phpunit-bridge": "^4.4|^5.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.12-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
-                    "Twig_": "lib/"
-                },
                 "psr-4": {
                     "Twig\\": "src/"
                 }
@@ -747,7 +743,6 @@
                 },
                 {
                     "name": "Twig Team",
-                    "homepage": "https://twig.symfony.com/contributors",
                     "role": "Contributors"
                 },
                 {
@@ -761,7 +756,7 @@
             "keywords": [
                 "templating"
             ],
-            "time": "2019-11-11T16:52:09+00:00"
+            "time": "2020-02-11T15:33:47+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
Hi @WyriHaximus ,

I'd like to suggest upgrading to latest Twig version with this pull request.

The QA toolchain went fine locally, but on Travis CI the `dependencies=highest` build matrix entry failed (see: https://travis-ci.com/github/dreadwarrior/reactphp-http-middleware-twig/builds/168214133). Currently I'm unsure how to fix, because it seems to be introduced with some `require-dev` packages.

I'm looking forward to your feedback.

Cheers,

Tommy